### PR TITLE
Add clickable feed link in Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The TickerTick API provides the latest stock news stories through a powerful que
 
 > Goal: make your first successful API call in under a minute.
 
-Fetch the 200 latest news stories for ticker `aapl` (Apple Inc.):
+Fetch [the 200 latest news stories for ticker `aapl`](https://api.tickertick.com/feed?q=z:aapl&n=200) (Apple Inc.):
 
 ```
 https://api.tickertick.com/feed?q=z:aapl&n=200


### PR DESCRIPTION
Hyperlinks the "200 latest news stories for \`aapl\`" text segment above the Quick Start code block to `https://api.tickertick.com/feed?q=z:aapl&n=200`, so there's a clickable link (the fenced code block itself can't be a link). The plain-text code block is kept for copy-paste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)